### PR TITLE
Fix opendatakit/opendatakit Issue #1177

### DIFF
--- a/scan_app/src/main/java/org/opendatakit/scan/android/activities/PhotographFormActivity.java
+++ b/scan_app/src/main/java/org/opendatakit/scan/android/activities/PhotographFormActivity.java
@@ -166,6 +166,7 @@ public class PhotographFormActivity extends BaseActivity {
 	protected void onDestroy() {
 		//Try to remove the forms directory if the photo couldn't be captured:
 		//Note: this won't delete the folder if it has any files in it.
+		new File(ScanUtils.getOutputPath(photoName) + "/segments").delete();
 		new File(ScanUtils.getOutputPath(photoName)).delete();
 		super.onDestroy();
 	}


### PR DESCRIPTION
The "segments" folder is created with the parent folder in PhotographFormActivity.onCreate so the parent folder is never empty when onDestroy is called.