### PR TITLE
remove no-longer-needed webkit resource id from application.

### DIFF
--- a/scan_app/src/main/AndroidManifest.xml
+++ b/scan_app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     </uses-feature>
 
     <uses-permission android:name="android.permission.CAMERA"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/scan_app/src/main/java/org/opendatakit/scan/application/Scan.java
+++ b/scan_app/src/main/java/org/opendatakit/scan/application/Scan.java
@@ -49,9 +49,4 @@ public class Scan extends CommonApplication {
     return R.raw.systemzip;
   }
 
-  @Override
-  public int getWebKitResourceId() {
-    return -1;
-  }
-
 }


### PR DESCRIPTION
Changes as part of fix for Survey double-page reload and bad navigation.